### PR TITLE
Rename name in package.json to actual repository name

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"email": "adrian@databank.io",
 		"url": "https://awspilot.dev"
 	},
-	"name": "cli-aws-lambda",
+	"name": "cli-lambda-deploy",
 	"description": "Deploy AWS Lambda functions from command line using a json or yaml config file.",
 	"keywords": [
 		"lambda",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 		"email": "adrian@databank.io",
 		"url": "https://awspilot.dev"
 	},
-	"name": "aws-lambda",
+	"name": "cli-aws-lambda",
 	"description": "Deploy AWS Lambda functions from command line using a json or yaml config file.",
 	"keywords": [
 		"lambda",


### PR DESCRIPTION
It's quite confusing having a different name for package.json and also the repo, my team has installed this package by mistake due to this discrepancy, would be nice if we could change it, please 🙏