### PR TITLE
Support using Ref in FunctionName

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -180,7 +180,6 @@ Lambda.prototype.deploy = function( program ) {
 		(typeof $config.FunctionName.Ref === "string") &&
 		($config.FunctionName.Ref.indexOf('env.') === 0)
 	) {
-		this.envs[ $config.FunctionName.Ref.split('env.')[1] ] = process.env[ $config.FunctionName.Ref.split('env.')[1] ]
 		$config.FunctionName = process.env[ $config.FunctionName.Ref.split('env.')[1] ]
 	}
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,7 +38,6 @@ Lambda.prototype._resolve_refs = function( $config ) {
 		$config.AWS_SECRET = process.env[ $config.AWS_SECRET.Ref.split('env.')[1] ]
 	}
 
-
 	if (
 		(typeof $config.Role === "object") &&
 		Object.prototype.hasOwnProperty.call( $config.Role , 'Ref') &&
@@ -47,6 +46,16 @@ Lambda.prototype._resolve_refs = function( $config ) {
 	) {
 		this.envs[ $config.Role.Ref.split('env.')[1] ] = process.env[ $config.Role.Ref.split('env.')[1] ]
 		$config.Role = process.env[ $config.Role.Ref.split('env.')[1] ]
+	}
+
+	if (
+		(typeof $config.FunctionName === "object") &&
+		Object.prototype.hasOwnProperty.call( $config.FunctionName , 'Ref') &&
+		(typeof $config.FunctionName.Ref === "string") &&
+		($config.FunctionName.Ref.indexOf('env.') === 0)
+	) {
+		this.envs[ $config.FunctionName.Ref.split('env.')[1] ] = process.env[ $config.FunctionName.Ref.split('env.')[1] ]
+		$config.FunctionName = process.env[ $config.FunctionName.Ref.split('env.')[1] ]
 	}
 
 	return $config;

--- a/lib/main.js
+++ b/lib/main.js
@@ -174,6 +174,16 @@ Lambda.prototype.deploy = function( program ) {
 	)
 		$config.Role = process.env[ $config.Role.Ref.split('env.')[1] ]
 
+	if (
+		(typeof $config.FunctionName === "object") &&
+		Object.prototype.hasOwnProperty.call( $config.FunctionName , 'Ref') &&
+		(typeof $config.FunctionName.Ref === "string") &&
+		($config.FunctionName.Ref.indexOf('env.') === 0)
+	) {
+		this.envs[ $config.FunctionName.Ref.split('env.')[1] ] = process.env[ $config.FunctionName.Ref.split('env.')[1] ]
+		$config.FunctionName = process.env[ $config.FunctionName.Ref.split('env.')[1] ]
+	}
+
 	if (!$config.FunctionName)
 		$config.FunctionName = program.split('/').slice(-1)[0]
 


### PR DESCRIPTION
This change adds the ability to use !Ref in FunctionName.

We plan on using this to during deployment to run a release task that pushes lambda to staging vs production lambda functions depending on environment variable config.