### PR TITLE
chore: migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -110,7 +110,7 @@ Lambda.prototype._parse_config_file = function( program ) {
 
 
 Lambda.prototype.deploy = function( program ) {
-	var aws = require( "aws-sdk" )
+	const { Lambda: AWSLambda } = require('@aws-sdk/client-lambda')
 
 	if (process.env.AWSPILOT_DOCKER_WORKDIR)
 		process.chdir(process.env.AWSPILOT_DOCKER_WORKDIR)
@@ -173,14 +173,13 @@ Lambda.prototype.deploy = function( program ) {
 		process.exit(-1);
 	}
 
-	aws.config.update({
-		accessKeyId: $config.AWS_KEY,
-		secretAccessKey: $config.AWS_SECRET,
-		region: $config.AWS_REGION
+	var lambdaV2 = new AWSLambda({
+		credentials: {
+			accessKeyId: $config.AWS_KEY,
+			secretAccessKey: $config.AWS_SECRET,
+		},
+		region: $config.AWS_REGION,
 	})
-
-	var lambdaV2 = new aws.Lambda( { apiVersion: "2015-03-31" } )
-
 
 	var _this = this
 
@@ -271,7 +270,7 @@ Lambda.prototype.deploy = function( program ) {
 		fs.unlinkSync( tmpfile )
 
 		lambdaV2.createFunction( paramsV2, function( err ) {
-			if ( err && err.code !== 'ResourceConflictException') {
+			if ( err && err.name !== 'ResourceConflictException') {
 				console.log("ERROR:", err )
 				if ( _this.settings.exitOnError !== false )
 					process.exit(-1);
@@ -279,7 +278,7 @@ Lambda.prototype.deploy = function( program ) {
 				return
 			}
 
-			if ( err && err.code === 'ResourceConflictException') {
+			if ( err && err.name === 'ResourceConflictException') {
 
 				// console.log("function exists, should update config and code")
 				var paramsV2 = {
@@ -355,7 +354,7 @@ Lambda.prototype.deploy = function( program ) {
 }
 
 Lambda.prototype.delete = function( program ) {
-	var aws = require( "aws-sdk" )
+	const { Lambda: AWSLambda } = require('@aws-sdk/client-lambda')
 
 	if (program.substr(-7) === '.lambda')
 		program = program.substr(0,program.length - 7)
@@ -405,26 +404,24 @@ Lambda.prototype.delete = function( program ) {
 	)
 		$config.Role = process.env[ $config.Role.Ref.split('env.')[1] ]
 
-
-	aws.config.update({
-		accessKeyId: $config.AWS_KEY,
-		secretAccessKey: $config.AWS_SECRET,
-		region: $config.AWS_REGION
-	})
-
 	if (!$config.FunctionName)
 		$config.FunctionName = program.split('/').slice(-1)[0]
 
-	var lambdaV2 = new aws.Lambda( { apiVersion: "2015-03-31" } )
-
+	var lambdaV2 = new AWSLambda({
+		credentials: {
+			accessKeyId: $config.AWS_KEY,
+			secretAccessKey: $config.AWS_SECRET,
+		},
+		region: $config.AWS_REGION,
+	})
 
 	lambdaV2.deleteFunction({ FunctionName: $config.FunctionName }, function( err ) {
-		if ( err && err.code !== 'ResourceNotFoundException') {
+		if ( err && err.name !== 'ResourceNotFoundException') {
 			console.log("delete error:", err )
 			process.exit(-1)
 		}
 
-		if ( err &&  err.code === 'ResourceNotFoundException')
+		if ( err &&  err.name === 'ResourceNotFoundException')
 			console.log("WARNING: deleteFunction ",$config.FunctionName,": ResourceNotFoundException " )
 		else
 			console.log( "Deleted!" );
@@ -433,7 +430,7 @@ Lambda.prototype.delete = function( program ) {
 
 
 Lambda.prototype.invoke = function( program ) {
-	var aws = require( "aws-sdk" )
+	const { Lambda: AWSLambda } = require('@aws-sdk/client-lambda')
 
 	if (program.substr(-7) === '.lambda')
 		program = program.substr(0,program.length - 7)
@@ -483,19 +480,16 @@ Lambda.prototype.invoke = function( program ) {
 	)
 		$config.Role = process.env[ $config.Role.Ref.split('env.')[1] ]
 
-
-	aws.config.update({
-		accessKeyId: $config.AWS_KEY,
-		secretAccessKey: $config.AWS_SECRET,
-		region: $config.AWS_REGION
-	})
-
 	if (!$config.FunctionName)
 		$config.FunctionName = program.split('/').slice(-1)[0]
 
-
-	var lambdaV2 = new aws.Lambda( { apiVersion: "2015-03-31" } )
-
+	var lambdaV2 = new AWSLambda({
+		credentials: {
+			accessKeyId: $config.AWS_KEY,
+			secretAccessKey: $config.AWS_SECRET,
+		},
+		region: $config.AWS_REGION,
+	})
 
 	var paramsV2 = {
 		FunctionName: $config.FunctionName,

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"lambda": "./bin/lambda"
 	},
 	"dependencies": {
-		"aws-sdk": "^2.814.0",
+		"@aws-sdk/client-lambda": "3.45.0",
 		"js-yaml": "^3.14.1",
 		"watchpack": "^2.0.0-beta.10",
 		"commander": "^3.0.2"


### PR DESCRIPTION
Fixes: https://github.com/awspilot/cli-lambda-deploy/issues/12

AWS SDK for JavaScript v2 will enter maintenance mode on September 8, 2024 and reach end-of-support on September 8, 2025. For more information, check blog post at https://a.co/cUPnyil

This PR migrates the AWS SDK for JavaScript v2 APIs to v3